### PR TITLE
Non english characters fix (regarding issue #3)

### DIFF
--- a/EldenRingFPSUnlockAndMore/EldenRingFPSUnlockAndMore.csproj
+++ b/EldenRingFPSUnlockAndMore/EldenRingFPSUnlockAndMore.csproj
@@ -69,9 +69,7 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
This is an alternative to choosing the path yourself . 

It will check if displayName has non-English/Standard characters and try to use InstallLocation instead.

I also added a check to see if the eldenring.exe is actually in the path if found before returning it to make sure its valid.

This will of course only work if installed in [some path]\\\\ELDEN RING 