### PR TITLE
non-English character fix (path not found)

### DIFF
--- a/EldenRingFPSUnlockAndMore/EldenRingFPSUnlockAndMore.csproj
+++ b/EldenRingFPSUnlockAndMore/EldenRingFPSUnlockAndMore.csproj
@@ -57,7 +57,8 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <PropertyGroup>
-    <ApplicationIcon>icon.ico</ApplicationIcon>
+    <ApplicationIcon>
+    </ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -137,9 +138,6 @@
       <ProductName>.NET Framework 3.5 SP1</ProductName>
       <Install>false</Install>
     </BootstrapperPackage>
-  </ItemGroup>
-  <ItemGroup>
-    <Resource Include="icon.ico" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/EldenRingFPSUnlockAndMore/MainWindow.xaml.cs
+++ b/EldenRingFPSUnlockAndMore/MainWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using System.Windows.Threading;
 using System.ComponentModel;
 using System.Management;
+using System.Text.RegularExpressions;
 
 namespace EldenRingFPSUnlockAndMore
 {
@@ -372,6 +373,8 @@ namespace EldenRingFPSUnlockAndMore
         {
             string displayName;
             string installDir;
+
+
             RegistryKey key;
 
             // search in: CurrentUser
@@ -380,16 +383,13 @@ namespace EldenRingFPSUnlockAndMore
             {
                 RegistryKey subkey = key.OpenSubKey(keyName);
                 displayName = subkey?.GetValue("DisplayName") as string;
+
                 if (displayName != null)
                 {
-                    if (p_name.Equals(displayName, StringComparison.OrdinalIgnoreCase) == true)
-                    {
-                        installDir = subkey.GetValue("InstallLocation") as string;
-                        if (!string.IsNullOrEmpty(installDir))
-                            return installDir;
-                    }
+                    if (InstallDirCheck(displayName, p_name, subkey, out installDir))
+                        return installDir;
                 }
-                
+
             }
 
             // search in: LocalMachine_32
@@ -398,14 +398,11 @@ namespace EldenRingFPSUnlockAndMore
             {
                 RegistryKey subkey = key.OpenSubKey(keyName);
                 displayName = subkey?.GetValue("DisplayName") as string;
+
                 if (displayName != null)
                 {
-                    if (p_name.Equals(displayName, StringComparison.OrdinalIgnoreCase) == true)
-                    {
-                        installDir = subkey.GetValue("InstallLocation") as string;
-                        if (!string.IsNullOrEmpty(installDir))
-                            return installDir;
-                    }
+                    if (InstallDirCheck(displayName, p_name, subkey, out installDir))
+                        return installDir;
                 }
             }
 
@@ -415,19 +412,51 @@ namespace EldenRingFPSUnlockAndMore
             {
                 RegistryKey subkey = key.OpenSubKey(keyName);
                 displayName = subkey?.GetValue("DisplayName") as string;
+
                 if (displayName != null)
                 {
-                    if (p_name.Equals(displayName, StringComparison.OrdinalIgnoreCase) == true)
-                    {
-                        installDir = subkey.GetValue("InstallLocation") as string;
-                        if (!string.IsNullOrEmpty(installDir))
-                            return installDir;
-                    }
-                }   
+                    if (InstallDirCheck(displayName, p_name, subkey, out installDir))
+                        return installDir;
+                }
             }
 
             // NOT FOUND
             return null;
+        }
+
+        /// <summary>
+        /// Check if installDir is valid
+        /// </summary>
+        /// <param name="displayName"></param>
+        /// <param name="p_name"></param>
+        /// <param name="subkey"></param>
+        /// <param name="installDir"></param>
+        /// <returns>True if valid</returns>
+        private static bool InstallDirCheck(string displayName, string p_name, RegistryKey subkey, out string installDir)
+        {
+            const string RegexNotASCII = @"[^\x00-\x80]+";
+            installDir = string.Empty;
+
+            // Check for non-English characters in displayName (CN, KR, ...) 
+            if (Regex.IsMatch(displayName, RegexNotASCII))
+            {
+                // check if InstallLocation path contains ELDEN RING sind displayName contains non-standard characters 
+                installDir = subkey.GetValue("InstallLocation") as string;
+                if (installDir != null && installDir.Contains(p_name))
+                {
+                    // Not needed but just an additional check to see if eldenring.exe is in the InstallLocation path
+                    if (File.Exists(installDir + @"\Game\eldenring.exe"))
+                        return true;
+                }
+            }
+            else if (p_name.Equals(displayName, StringComparison.OrdinalIgnoreCase))
+            {
+                installDir = subkey.GetValue("InstallLocation") as string;
+                if (!string.IsNullOrEmpty(installDir))
+                    return true;
+            }
+
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
#3 alternative fix to select the file yourself

This is an alternative to choosing the path yourself .

It will check if displayName has non-English/Standard characters and try to use InstallLocation instead.
I also added a check to see if the eldenring.exe is actually in the path if found before returning it to make sure its valid.


**(had to remove the icon.ico since its not on github so i was not able to compile)**